### PR TITLE
bionic: Allow devices to add device specfic static libs

### DIFF
--- a/libc/Android.mk
+++ b/libc/Android.mk
@@ -1072,6 +1072,9 @@ LOCAL_SRC_FILES_arm += \
     arch-arm/bionic/atexit_legacy.c \
     arch-common/bionic/crtend_so.S
 
+# Allow devices to provide additional symbols
+LOCAL_WHOLE_STATIC_LIBRARIES += $(BOARD_PROVIDES_ADDITIONAL_BIONIC_STATIC_LIBS)
+
 include $(BUILD_SHARED_LIBRARY)
 
 


### PR DESCRIPTION
This provides a convenient (albeit powerful enough to be dangerous)
hook to add symbols needed to support vendor blobs that do not
necessarily match our source code.

Doing so via this hook has several advantages over patching the
code in question:

* The hacks do no pollute other repositories
* The hacks do not have any risk of breaking any other devices
* The hacks don't just live forever when we forget they exist
* The hacks are all easy to find by locating them together

When using this, please take extra care to include only the
minimal code to support the change.  Keep in mind that all
code (and all libraries your code links against) will be
part of the address space of every single process in
the system!

Change-Id: I6dcd9ad7cee330febe1a974619144d378b67b364